### PR TITLE
fix(replay): add head_insert_arquivo template with top-frame redirect

### DIFF
--- a/framed/config.yaml
+++ b/framed/config.yaml
@@ -1,8 +1,5 @@
 collections:
-  
-  # The reason that we have 'wayback' as collection is to have the same URL has our production environment.
-  # So we have for example:
-  #   http://localhost:8081/wayback/19990125085708/http://fccn.pt:80/
+
   wayback:
     
     # Example of configuration to use local cdx indexes and an arcproxy server.
@@ -62,7 +59,7 @@ collections:
     # Example that use Arquivo.pt production environment with Memento API
     #
     index_group:
-      arquivo_memento: memento+https://arquivo.pt/wayback/
+      arquivo_memento: memento+https://preprod.arquivo.pt/wayback/
     
     # Example that use Arquivo.pt production environment with CDX API
     # index_group:
@@ -76,7 +73,7 @@ collections:
       #
       # Example to use the production environment
       #
-      arquivoweb_app_url: https://arquivo.pt
+      arquivoweb_app_url: http://localhost:3000
 
       #
       # Example to use the preprod environment
@@ -95,14 +92,14 @@ collections:
       googleAnalyticsToken: G-6VRZXCHDJ1
 
 # Templates
-head_insert_html: head_insert_mobile.html
+head_insert_html: head_insert_arquivo.html
 frame_insert_html: frame_insert_mobile.html
 error_html: error_mobile.html
 not_found_html: not_found_mobile.html
 banner_html: banner_blank.html
 
 
-framed_replay: true
+framed_replay: false
 redirect_exact: true
 debug: true
 

--- a/framed/templates/head_insert_arquivo.html
+++ b/framed/templates/head_insert_arquivo.html
@@ -1,0 +1,58 @@
+<!-- WB Insert -->
+<script>
+{% set urlsplit = cdx.url | urlsplit %}
+  wbinfo = {};
+  wbinfo.url = "{{ cdx.url }}";
+  wbinfo.timestamp = "{{ cdx.timestamp }}";
+  wbinfo.request_ts = "{{ wb_url.timestamp }}";
+  wbinfo.prefix = decodeURI("{{ wb_prefix }}");
+  wbinfo.mod = "{{ replay_mod }}";
+  wbinfo.is_framed = true;
+  wbinfo.top_host = "*";
+  wbinfo.is_live = {{ is_live | tobool }};
+  wbinfo.coll = "{{ coll }}";
+  wbinfo.proxy_magic = "{{ env.pywb_proxy_magic }}";
+  wbinfo.static_prefix = "{{ static_prefix }}/";
+  wbinfo.enable_auto_fetch = {{ config.enable_auto_fetch | tobool }};
+  if (window.parent === window) {
+    window.location.replace("{{ metadata.arquivoweb_app_url }}/wayback/" + wbinfo.timestamp + "/" + wbinfo.url);
+  }
+</script>
+{% if env.pywb_proxy_magic %}
+{% set whichWombat = 'wombatProxyMode.js' %}
+{% else %}
+{% set whichWombat = 'wombat.js' %}
+{% endif %}
+{% if not wb_url.is_banner_only or (env.pywb_proxy_magic and (config.enable_auto_fetch or config.proxy.enable_wombat)) %}
+<script src='{{ static_prefix }}/{{ whichWombat }}'> </script>
+<script>
+  wbinfo.wombat_ts = "{{ wombat_ts }}";
+  wbinfo.wombat_sec = "{{ wombat_sec }}";
+  wbinfo.wombat_scheme = "{{ urlsplit.scheme }}";
+  wbinfo.wombat_host = "{{ urlsplit.netloc }}";
+  wbinfo.wombat_sec = "{{ cdx.timestamp | format_ts('%s') }}";
+  wbinfo.wombat_opts = {};
+  if (window && window._WBWombatInit) {
+    window._WBWombatInit(wbinfo);
+  }
+</script>
+{% else %}
+<script>
+  window.devicePixelRatio = 1;
+</script>
+{% endif %}
+
+{% if config.enable_flash_video_rewrite %}
+<script src='{{ static_prefix }}/vidrw.js'> </script>
+{% endif %}
+
+<script src="{{ static_prefix }}/js/ruffle/ruffle.js"></script>
+<script>
+window.RufflePlayer.config.autoplay = "on";
+window.RufflePlayer.config.unmuteOverlay = "hidden";
+</script>
+
+
+{{ banner_html }}
+
+<!-- End WB Insert -->


### PR DESCRIPTION
## Summary

- New `head_insert_arquivo.html`: hardcodes `is_framed=true` and `top_host='*'` so wombat.js sends postMessages to the arquivo.pt parent frame
- On direct access (new tab), redirects to `arquivoweb_app_url/wayback/{ts}/{url}` instead of showing raw pywb UI
- Set `framed_replay: false`, collection `wayback:`, Memento pointing to preprod for local dev

## Test plan

- [ ] Open `http://localhost:3000/wayback/{timestamp}/{url}` and verify the replay iframe loads correctly
- [ ] Click a link inside the iframe that opens in a new tab — should redirect to the webapp (`localhost:3000/wayback/...`)
- [ ] Verify postMessages are received by the webapp (URL and timestamp update in the header and left nav)
- [ ] Confirm `framed_replay: false` serves content directly without pywb's own frame UI

Refs: arquivo/pwa-technologies#1559